### PR TITLE
chore(ci): fixed target branches for `run-tests.yml` workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: run-tests
 
 on:
   push: 
-    branches: [main]
+    branches: [master]
   pull_request: 
-    branches: [main]
+    branches: [master]
 
 jobs:
   test:


### PR DESCRIPTION
# Explain your changes
The `run-tests.yml` workflow should be targeting the `master` branch not `main`.

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
